### PR TITLE
BUG FIX: Import Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,8 @@ Note: vLLM Component Remote Code Execution Protection. In the code below, if the
 
 ```python
 import os
-from vllm import LLM, SamplingParams
+from vllm.entrypoints.llm import LLM
+from vllm.sampling_params import SamplingParams
 
 model_path=os.environ.get('MODEL_PATH')
 


### PR DESCRIPTION
#### Issue Summary:
When attempting to run the following code:
```python
from vllm import LLM, SamplingParams
```
an `ImportError` occurs:
```
ImportError: cannot import name 'LLM' from 'vllm' (unknown location)
```

#### Solution:
To resolve this import error, update the import statements as follows:
```python
from vllm.entrypoints.llm import LLM
from vllm.sampling_params import SamplingParams
```

This change ensures that the `LLM` and `SamplingParams` classes are imported from their correct locations within the `vllm` module.